### PR TITLE
Feat: Create users registration

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class UsersController < ApplicationController
+      skip_before_action :authenticate!, only: [:create]
+
+      def create
+        user = User.new(user_params)
+        if user.save
+          token = JsonWebToken.encode(id: user.id, exp: 24.hours.from_now.to_i)
+          render json: { token: token }, status: :created
+        else
+          render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def user_params
+        params.permit(:name, :email, :password, :password_confirmation)
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_secure_password
 
   validates :email, presence: true, uniqueness: true
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: 'Invalid email format' }
   validates :password, presence: true, length: { minimum: 6 }
 
   enum :role, { librarian: 0, member: 1 }, default: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :books, only: [:index]
       resources :auth, only: %i[create destroy]
+      resources :users, only: [:create]
     end
   end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Users', type: :request do
+  describe 'POST /api/v1/users' do
+    subject(:action) { post '/api/v1/users', params: payload }
+    let(:json_response) { JSON.parse(response.body) }
+
+    context 'when email is already taken' do
+      let!(:user) { create(:user, email: 'taken@domain.com') }
+      let(:payload) do
+        {
+          name: 'Test User',
+          email: user.email,
+          password: 'password123',
+          password_confirmation: 'password123'
+        }
+      end
+
+      it 'returns an error message' do
+        expect { action }.not_to change(User, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['errors']).to include('Email has already been taken')
+      end
+    end
+
+    context 'when password confirmation does not match' do
+      let(:payload) do
+        {
+          name: 'Test User',
+          email: 'john@doe.com',
+          password: 'password123',
+          password_confirmation: 'different_password'
+        }
+      end
+
+      it 'returns an error message' do
+        expect { action }.not_to change(User, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['errors']).to include("Password confirmation doesn't match Password")
+      end
+    end
+
+    context 'when email format is invalid' do
+      let(:payload) do
+        {
+          name: 'Test User',
+          email: 'invalid_email_format',
+          password: 'password123',
+          password_confirmation: 'password123'
+        }
+      end
+
+      it 'returns an error message' do
+        expect { action }.not_to change(User, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['errors']).to include('Email Invalid email format')
+      end
+    end
+
+    context 'when payload is all ok and user does not exists' do
+      let(:payload) do
+        {
+          name: 'Test User',
+          email: 'john@doe.com',
+          password: 'password123',
+          password_confirmation: 'password123'
+        }
+      end
+
+      it 'creates a new user and returns a token' do
+        expect { action }.to change(User, :count).by(1)
+        expect(response).to have_http_status(:created)
+        expect(json_response).to match('token' => anything)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a new user registration feature in the API, including the creation of a `UsersController`, updates to user validations, routing changes, and comprehensive request specs. The most important changes are grouped below by theme.

### User Registration Feature

* Added `UsersController` in `app/controllers/api/v1/users_controller.rb` to handle user creation. It includes JWT token generation upon successful registration and strong parameter validation.
* Updated `config/routes.rb` to include a new route for user creation under the `v1` namespace.

### User Model Enhancements

* Enhanced email validation in `User` model to ensure proper email format using `URI::MailTo::EMAIL_REGEXP`.

### Test Coverage

* Added request specs in `spec/requests/api/v1/users_spec.rb` to test various scenarios for user registration, including invalid email formats, duplicate emails, mismatched passwords, and successful user creation.